### PR TITLE
Blocks teleportation out of gateway missions

### DIFF
--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -12,6 +12,7 @@ Unused icons for new areas are "awaycontent1" ~ "awaycontent30"
 	ambience_index = AMBIENCE_AWAY
 	sound_environment = SOUND_ENVIRONMENT_ROOM
 	skip_minimap_rendering = TRUE
+	area_flags = NOTELEPORT
 
 /area/awaymission/museum
 	name = "Nanotrasen Museum"


### PR DESCRIPTION

## About The Pull Request

People are teleporting in and out of gateway missions to heal and bring back loot and more supplies in. 

## Why It's Good For The Game

No more gamering gateway missions

## Changelog


:cl:
balance: Stopped teleportation into gateway missions.
/:cl:
